### PR TITLE
[codex] Add benchmarks and refactor svumps API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *.jl.cov
 *.jl.*.cov
 *.jl.mem
+*.jl.*.mem
 docs/build
 docs/Manifest.toml
 Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SuperVUMPS"
 uuid = "251f20e1-0c2c-4c9f-ab3f-16280b56c0f4"
-version = "1.6.2"
+version = "1.6.3"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]

--- a/benchmark/profile_spin_chain.jl
+++ b/benchmark/profile_spin_chain.jl
@@ -1,0 +1,54 @@
+using Profile
+using Printf
+
+using SuperVUMPS
+
+include(joinpath(@__DIR__, "..", "test", "spin_models.jl"))
+using .SpinModels
+
+function parse_arg(name, default)
+    prefix = "--$(name)="
+    for arg in ARGS
+        if startswith(arg, prefix)
+            value = arg[length(prefix) + 1:end]
+            return default isa AbstractString ? value : parse(typeof(default), value)
+        end
+    end
+    default
+end
+
+function parse_model()
+    model = parse_arg("model", "tfim")
+    if model == "tfim"
+        "transverse-field Ising", transverse_field_ising(; g = 1.0)
+    elseif model == "heisenberg"
+        "Heisenberg", heisenberg()
+    else
+        error("unknown model: $(model)")
+    end
+end
+
+function main()
+    name, h = parse_model()
+    χ = parse_arg("chi", 8)
+    iterations = parse_arg("iterations", 3)
+    tol = parse_arg("tol", 1e-6)
+    repeats = parse_arg("repeats", 5)
+
+    @printf("Profiling %s: chi=%d iterations=%d tol=%g repeats=%d\n", name, χ, iterations, tol, repeats)
+    A = canonicalMPS(ComplexF64, χ, 2)
+
+    svumps(h, A; tol, iterations)
+    Profile.clear()
+    @profile begin
+        for _ in 1:repeats
+            svumps(h, A; tol, iterations)
+        end
+    end
+
+    data = Profile.fetch()
+    @printf("Captured %d instruction-pointer samples\n\n", length(data))
+    Profile.print(format = :flat, sortedby = :count, maxdepth = 80, mincount = 2)
+end
+
+main()

--- a/benchmark/spin_chains.jl
+++ b/benchmark/spin_chains.jl
@@ -1,0 +1,58 @@
+using LinearAlgebra
+using Printf
+using Random
+
+using SuperVUMPS
+
+include(joinpath(@__DIR__, "..", "test", "spin_models.jl"))
+using .SpinModels
+
+function parse_arg(name, default)
+    prefix = "--$(name)="
+    for arg in ARGS
+        startswith(arg, prefix) && return parse(typeof(default), arg[length(prefix) + 1:end])
+    end
+    default
+end
+
+function median_time(f, repeats)
+    times = Vector{Float64}(undef, repeats)
+    for i in eachindex(times)
+        GC.gc()
+        times[i] = @elapsed f()
+    end
+    sort!(times)
+    times[cld(length(times), 2)]
+end
+
+function run_case(name, h, exact_energy; χ, iterations, tol, repeats, verbose)
+    Random.seed!(1234)
+    A0 = canonicalMPS(ComplexF64, χ, 2; verbose)
+
+    E, A = svumps(h, A0; tol, iterations, verbose)
+    energy = real(local_energy(A.AL, A.AC, h))
+    @printf("%-24s E = %.12f check = %.12f error = %.6e\n", name, E, energy, abs(E - exact_energy))
+
+    GC.gc()
+    elapsed = median_time(repeats) do
+        svumps(h, A0; tol, iterations, verbose)
+    end
+
+    GC.gc()
+    allocated = @allocated svumps(h, A0; tol, iterations, verbose = false)
+    @printf("%-24s time = %.6f s allocated = %.3f MiB\n", name, elapsed, allocated / 2.0^20)
+end
+
+function main()
+    χ = parse_arg("chi", 4)
+    iterations = parse_arg("iterations", 10)
+    tol = parse_arg("tol", 1e-8)
+    verbose = parse_arg("verbose", false)
+    repeats = parse_arg("repeats", 3)
+
+    @printf("SuperVUMPS spin-chain benchmark: chi=%d iterations=%d tol=%g repeats=%d verbose=%s\n", χ, iterations, tol, repeats, verbose)
+    run_case("transverse-field Ising", transverse_field_ising(; g = 1.0), -4 / pi; χ, iterations, tol, repeats, verbose)
+    run_case("Heisenberg", heisenberg(), 1 / 4 - log(2); χ, iterations, tol, repeats, verbose)
+end
+
+main()

--- a/src/SuperVUMPS.jl
+++ b/src/SuperVUMPS.jl
@@ -8,7 +8,7 @@ using Optim
 using KrylovKit
 using Printf
 
-export svumps, local_energy, Hamiltonian_construction, canonicalMPS, MixedCanonicalMPS, conjugateMPS
+export svumps, svumps_hamiltonian, local_energy, Hamiltonian_construction, canonicalMPS, MixedCanonicalMPS, conjugateMPS
 
 include("vumps.jl")
 

--- a/src/vumps.jl
+++ b/src/vumps.jl
@@ -52,10 +52,42 @@ Zygote.@adjoint function polar(A; rev = false)
     end
 end
 
-function rightorth(A, C = Matrix{eltype(A)}(I, size(A, 1), size(A, 1)); tol = 1e-12, maxiter = 100, kwargs...)
+_verbosity(verbose) = verbose isa Bool ? (verbose ? 1 : 0) : verbose
+_show_trace(verbose) = verbose isa Bool ? verbose : verbose > 0
+
+function _hermitian_difference(A, B)
+    C = A .+ A'
+    C .-= B
+    C .-= B'
+    C
+end
+
+function _project_tangent_basis(AC)
+    χ, d, = size(AC)
+    U1, S1, V1 = svd(reshape(AC, χ, d * χ))
+    U2, S2, V2 = svd(reshape(AC, χ * d, χ) * U1)
+    U2 .= U2 * V2'
+    V2 .= U1
+    U1, S1, V1, U2, S2, V2
+end
+
+function _scaled_tangent_components(dAC, U1, V1, U2, V2, DinvsqrtS1, DsqrtS1, DinvsqrtS2, DsqrtS2)
+    χ, d, = size(dAC)
+    K1 = DinvsqrtS1 * (U1' * reshape(dAC, χ, d * χ) * V1) * DsqrtS1
+    K2 = DinvsqrtS2 * (V2' * reshape(dAC, χ * d, χ)' * U2) * DsqrtS2
+    K1, K2
+end
+
+function _project_tangent_correction(h, χ, d, U1, V1, U2, V2, DinvsqrtS1, DsqrtS1, DinvsqrtS2, DsqrtS2)
+    hp = h .+ h'
+    reshape(U1 * (DinvsqrtS1 * hp * DsqrtS1) * V1', χ, d, χ) .- reshape(U2 * (DsqrtS2 * hp * DinvsqrtS2) * V2', χ, d, χ)
+end
+
+function rightorth(A, C = Matrix{eltype(A)}(I, size(A, 1), size(A, 1)); tol = 1e-12, maxiter = 100, verbose = false, kwargs...)
     χ, d, = size(A)
     Abar = conj(A)
-    _, vecs1 = eigsolve(C * C', 1, :LR; ishermitian = false, tol = 1e-2tol, verbosity = 0, kwargs...) do X
+    verbosity = _verbosity(verbose)
+    _, vecs1 = eigsolve(C * C', 1, :LR; ishermitian = false, tol = 1e-2tol, verbosity, kwargs...) do X
         ein"ijk, (ljm, mk) -> li"(Abar, A, X)
     end
     ρ = vecs1[1]
@@ -68,7 +100,7 @@ function rightorth(A, C = Matrix{eltype(A)}(I, size(A, 1), size(A, 1)); tol = 1e
     numiter = 0
     while δ > tol && numiter < maxiter
         ARbar = conj(AR)
-        _, vecs = eigsolve(L, 1, :LR; ishermitian = false, tol = 1e-2δ, verbosity = 0, kwargs...) do X
+        _, vecs = eigsolve(L, 1, :LR; ishermitian = false, tol = 1e-2δ, verbosity, kwargs...) do X
             ein"ijk, (ljm, mk) -> li"(ARbar, A, X)
         end
         C = vecs[1]
@@ -82,14 +114,18 @@ function rightorth(A, C = Matrix{eltype(A)}(I, size(A, 1), size(A, 1)); tol = 1e
     L, AR
 end
 
-struct UniformMPS <: Manifold end
+struct UniformMPS <: Manifold
+    verbosity::Int
+end
 
-function Optim.retract!(::UniformMPS, AC; tol = 1e-12)
+UniformMPS(; verbose = false) = UniformMPS(_verbosity(verbose))
+
+function Optim.retract!(m::UniformMPS, AC; tol = 1e-12)
     χ, d, = size(AC)
     L, C = polar(reshape(AC, χ * d, χ))
     AL = reshape(L, χ, d, χ)
     ALbar = conj(AL)
-    _, vecs1 = eigsolve(C * C', 1, :LR; ishermitian = false, tol = 1e-2tol, verbosity = 0) do x
+    _, vecs1 = eigsolve(C * C', 1, :LR; ishermitian = false, tol = 1e-2tol, verbosity = m.verbosity) do x
         ein"ijk, (ljm, mk) -> li"(ALbar, AL, x)
     end
     X = vecs1[1]
@@ -100,27 +136,24 @@ function Optim.retract!(::UniformMPS, AC; tol = 1e-12)
     AC ./= norm(AC)
 end
 
-function Optim.project_tangent!(::UniformMPS, dAC, AC; tol = 1e-12)
+function Optim.project_tangent!(m::UniformMPS, dAC, AC; tol = 1e-12)
     χ, d, = size(AC)
-    U1, S1, V1 = svd(reshape(AC, χ, d * χ))
-    U2, S2, V2 = svd(reshape(AC, χ * d, χ) * U1)
-    U2 .= U2 * V2'
-    V2 .= U1
+    U1, S1, V1, U2, S2, V2 = _project_tangent_basis(AC)
     sqrtS1 = sqrt.(S1)
     invsqrtS1 = inv.(sqrtS1)
     sqrtS2 = sqrt.(S2)
     invsqrtS2 = inv.(sqrtS2)
-    K1 = Diagonal(invsqrtS1) * (U1' * reshape(dAC, χ, d * χ) * V1) * Diagonal(sqrtS1)
-    K2 = Diagonal(invsqrtS2) * (V2' * reshape(dAC, χ * d, χ)' * U2) * Diagonal(sqrtS2)
-    temp, = linsolve((x -> cat(real(x), imag(x); dims = 3))(K1 .+ K1' .- (K2 .+ K2')); ishermitian = true, isposdef = true, tol = tol, verbosity = 0) do x
-        h = x[:, :, 1] .+ im .* x[:, :, 2]
-        dac = reshape(U1 * (Diagonal(invsqrtS1) * (h .+ h') * Diagonal(sqrtS1)) * V1', χ, d, χ) .- reshape(U2 * (Diagonal(sqrtS2) * (h .+ h') * Diagonal(invsqrtS2)) * V2', χ, d, χ)
-        k1 = Diagonal(invsqrtS1) * (U1' * reshape(dac, χ, d * χ) * V1) * Diagonal(sqrtS1)
-        k2 = Diagonal(invsqrtS2) * (V2' * reshape(dac, χ * d, χ)' * U2) * Diagonal(sqrtS2)
-        (x -> cat(real(x), imag(x); dims = 3))(k1 .+ k1' .- (k2 .+ k2'))
+    DsqrtS1 = Diagonal(sqrtS1)
+    DinvsqrtS1 = Diagonal(invsqrtS1)
+    DsqrtS2 = Diagonal(sqrtS2)
+    DinvsqrtS2 = Diagonal(invsqrtS2)
+    K1, K2 = _scaled_tangent_components(dAC, U1, V1, U2, V2, DinvsqrtS1, DsqrtS1, DinvsqrtS2, DsqrtS2)
+    temp, = linsolve(_hermitian_difference(K1, K2); ishermitian = true, isposdef = true, tol = tol, verbosity = m.verbosity) do h
+        dac = _project_tangent_correction(h, χ, d, U1, V1, U2, V2, DinvsqrtS1, DsqrtS1, DinvsqrtS2, DsqrtS2)
+        k1, k2 = _scaled_tangent_components(dac, U1, V1, U2, V2, DinvsqrtS1, DsqrtS1, DinvsqrtS2, DsqrtS2)
+        _hermitian_difference(k1, k2)
     end
-    h = temp[:, :, 1] .+ im .* temp[:, :, 2]
-    dAC .-= reshape(U1 * (Diagonal(invsqrtS1) * (h .+ h') * Diagonal(sqrtS1)) * V1', χ, d, χ) .- reshape(U2 * (Diagonal(sqrtS2) * (h .+ h') * Diagonal(invsqrtS2)) * V2', χ, d, χ)
+    dAC .-= _project_tangent_correction(temp, χ, d, U1, V1, U2, V2, DinvsqrtS1, DsqrtS1, DinvsqrtS2, DsqrtS2)
     dAC .-= AC .* real(dot(AC, dAC))
 end
 
@@ -131,86 +164,130 @@ struct MixedCanonicalMPS{T <: Complex}
     C::Matrix{T}
 end
 
-function regularize_left(AL, ALbar, C, Cbar, h, χ; tol = 1e-12)
+function regularize_left(AL, ALbar, C, Cbar, h, χ; tol = 1e-12, verbose = false)
     r = ein"ij, kj -> ik"(Cbar, C)
-    l = Matrix{ComplexF64}(I, χ, χ)
+    l = Matrix{eltype(C)}(I, χ, χ)
 
     initial = ein"ijk, (klm, (jlno, (inq, qor))) -> mr"(ALbar, ALbar, h, AL, AL)
-    Lh, = linsolve(x -> x .- ein"(ij, ikl), jkm -> lm"(x, ALbar, AL) .+ ein"ij, ij -> "(x, r)[] .* l, initial .- ein"ij, ij -> "(initial, r)[] .* l; ishermitian = false, tol = tol, verbosity = 0)
+    Lh, = linsolve(x -> x .- ein"(ij, ikl), jkm -> lm"(x, ALbar, AL) .+ ein"ij, ij -> "(x, r)[] .* l, initial .- ein"ij, ij -> "(initial, r)[] .* l; ishermitian = false, tol = tol, verbosity = _verbosity(verbose))
     (Lh .+ Lh') ./ 2
 end
 
-function regularize_right(AR, ARbar, C, Cbar, h, χ; tol = 1e-12)
+function regularize_right(AR, ARbar, C, Cbar, h, χ; tol = 1e-12, verbose = false)
     l = ein"ij, ik -> jk"(Cbar, C)
-    r = Matrix{ComplexF64}(I, χ, χ)
+    r = Matrix{eltype(C)}(I, χ, χ)
 
     initial = ein"ijk, (klm, (jlno, (pnq, qom))) -> ip"(ARbar, ARbar, h, AR, AR)
-    Rh, = linsolve(x -> x .- ein"ijk, (mjl, kl) -> im"(ARbar, AR, x) .+ r .* ein"ij, ij -> "(l, x)[], initial .- r .* ein"ij, ij -> "(l, initial)[]; ishermitian = false, tol = tol, verbosity = 0)
+    Rh, = linsolve(x -> x .- ein"ijk, (mjl, kl) -> im"(ARbar, AR, x) .+ r .* ein"ij, ij -> "(l, x)[], initial .- r .* ein"ij, ij -> "(l, initial)[]; ishermitian = false, tol = tol, verbosity = _verbosity(verbose))
     (Rh .+ Rh') ./ 2
 end
 
-function canonicalMPS(T, χ, d)
+function canonicalMPS(T, χ, d; verbose = false)
     U, _, V = svd(randn(T, χ * d, χ))
     AL = Array(reshape(U * V', χ, d, χ))
-    C, AR = rightorth(AL)
+    C, AR = rightorth(AL; verbose)
     AC = ein"ijk, kl -> ijl"(AL, C)
     MixedCanonicalMPS(AL, AR, AC, C)
 end
 
 conjugateMPS(A) = MixedCanonicalMPS(conj(A.AL), conj(A.AR), conj(A.AC), conj(A.C))
 
-local_energy(AL, AC, h::Array{T, 4}) where T = ein"ijk, (klm, (jlno, (inp, pom))) -> "(conj(AL), conj(AC), h, AL, AC)[]
-local_energy(AL, AC, h::Array{T, 6}) where T = ein"ijk, (klm, (mno, (jlnpqr, (ips, (sqt, tro))))) -> "(conj(AL), conj(AL), conj(AC), h, AL, AL, AC)[]
-local_energy(AL, AC, h::Array{T, 8}) where T = ein"ijk, (klm, (mno, (opq, (jlnprstu, (irv, (vsw, (wtx, xuq))))))) -> "(conj(AL), conj(AL), conj(AL), conj(AC), h, AL, AL, AL, AC)[]
+_energy_eltype(AL, AC, h) = promote_type(eltype(AL), eltype(AC), eltype(h))
+_energy_scalar(x, ::Type{T}) where T = x[]::T
 
-function Hamiltonian_construction(h::Array{T, 4}, A, E; tol = 1e-12) where T
-    χ, d, = size(A.AL)
-    Abar = conjugateMPS(A)
-    hr = h .- E .* ein"ij, kl -> ikjl"(Matrix{Float64}(I, d, d), Matrix{Float64}(I, d, d))
-    Lh = regularize_left(A.AL, Abar.AL, A.C, Abar.C, hr, χ; tol = 1e-2tol)
-    Rh = regularize_right(A.AR, Abar.AR, A.C, Abar.C, hr, χ; tol = 1e-2tol)
+local_energy(AL, AC, h::Array{T, 4}) where T = _energy_scalar(ein"ijk, (klm, (jlno, (inp, pom))) -> "(conj(AL), conj(AC), h, AL, AC), _energy_eltype(AL, AC, h))
+local_energy(AL, AC, h::Array{T, 6}) where T = _energy_scalar(ein"ijk, (klm, (mno, (jlnpqr, (ips, (sqt, tro))))) -> "(conj(AL), conj(AL), conj(AC), h, AL, AL, AC), _energy_eltype(AL, AC, h))
+local_energy(AL, AC, h::Array{T, 8}) where T = _energy_scalar(ein"ijk, (klm, (mno, (opq, (jlnprstu, (irv, (vsw, (wtx, xuq))))))) -> "(conj(AL), conj(AL), conj(AL), conj(AC), h, AL, AL, AL, AC), _energy_eltype(AL, AC, h))
+
+function _shift_hamiltonian(h, E, d)
+    Id = Matrix{Float64}(I, d, d)
+    h .- E .* ein"ij, kl -> ikjl"(Id, Id), Id
+end
+
+function _regularized_environments(A, Abar, hr, χ; tol, verbose)
+    Lh = regularize_left(A.AL, Abar.AL, A.C, Abar.C, hr, χ; tol = 1e-2tol, verbose)
+    Rh = regularize_right(A.AR, Abar.AR, A.C, Abar.C, hr, χ; tol = 1e-2tol, verbose)
+    Lh, Rh
+end
+
+function _effective_hamiltonian_terms(A, Abar, hr)
     HL = ein"ijk, (jlno, inp) -> klpo"(Abar.AL, hr, A.AL)
     HC = ein"ijk, (lmn, (jmop, (ioq, rpn))) -> klqr"(Abar.AL, Abar.AR, hr, A.AL, A.AR)
     HR = ein"klm, (jlno, pom) -> jknp"(Abar.AR, hr, A.AR)
-    HAC = ein"klpo, ij -> klipoj"(HL, Matrix{Float64}(I, χ, χ)) .+ ein"jknp, hi -> hjkinp"(HR, Matrix{Float64}(I, χ, χ)) .+
-    ein"ij, kl, mn -> ikmjln"(Lh, Matrix{Float64}(I, d, d), Matrix{Float64}(I, χ, χ)) .+ ein"ij, kl, mn -> ikmjln"(Matrix{Float64}(I, χ, χ), Matrix{Float64}(I, d, d), Rh)
-    HC_rtn = HC .+ ein"ij, kl -> ikjl"(Lh, Matrix{Float64}(I, χ, χ)) .+ ein"ij, kl -> ikjl"(Matrix{Float64}(I, χ, χ), Rh)
+    HL, HC, HR
+end
+
+function _assemble_effective_hamiltonians(HL, HC, HR, Lh, Rh, Id, Iχ)
+    HAC = ein"klpo, ij -> klipoj"(HL, Iχ) .+ ein"jknp, hi -> hjkinp"(HR, Iχ) .+
+    ein"ij, kl, mn -> ikmjln"(Lh, Id, Iχ) .+ ein"ij, kl, mn -> ikmjln"(Iχ, Id, Rh)
+    HC_rtn = HC .+ ein"ij, kl -> ikjl"(Lh, Iχ) .+ ein"ij, kl -> ikjl"(Iχ, Rh)
     HAC, HC_rtn
 end
 
-function svumps(h::T, A; tol = 1e-8, iterations = 1000, Hamiltonian = false) where T
-    ignore() do
-        χ, d, = size(A.AL)
-        U, _, V = svd(A.C)
-        AC = ein"ij, (jkl, lm) -> ikm"(U', A.AC, V)
+function Hamiltonian_construction(h::Array{T, 4}, A, E; tol = 1e-12, verbose = false) where T
+    χ, d, = size(A.AL)
+    Abar = conjugateMPS(A)
+    Iχ = Matrix{Float64}(I, χ, χ)
+    hr, Id = _shift_hamiltonian(h, E, d)
+    Lh, Rh = _regularized_environments(A, Abar, hr, χ; tol, verbose)
+    HL, HC, HR = _effective_hamiltonian_terms(A, Abar, hr)
+    HAC, HC_rtn = _assemble_effective_hamiltonians(HL, HC, HR, Lh, Rh, Id, Iχ)
+    TH = promote_type(eltype(A.AL), eltype(h))
+    HAC::Array{TH, 6}, HC_rtn::Array{TH, 4}
+end
 
-        function fg!(F, G, x)
-            val, (dx,) = withgradient(x) do ac
-                l, = polar(reshape(ac, χ * d, χ))
-                al = reshape(l, χ, d, χ)
-                real(local_energy(al, ac, h))
-            end
-            if G !== nothing
-                G .= dx
-            end
-            if F !== nothing
-                return val
-            end
-        end
-        res = optimize(only_fg!(fg!), AC, LBFGS(manifold = UniformMPS()), Optim.Options(g_abstol = tol, allow_f_increases = true, iterations = iterations))
+function _initial_ac(A)
+    U, _, V = svd(A.C)
+    ein"ij, (jkl, lm) -> ikm"(U', A.AC, V)
+end
 
-        AC .= Optim.minimizer(res)
-        L, = polar(reshape(AC, χ * d, χ))
-        AL = reshape(L, χ, d, χ)
-        C, R = polar(reshape(AC, χ, d * χ); rev = true)
-        AR = reshape(R, χ, d, χ)
-        A = MixedCanonicalMPS(AL, AR, AC, C)
+function _objective_gradient!(F, G, x, h, χ, d)
+    val, (dx,) = withgradient(x) do ac
+        l, = polar(reshape(ac, χ * d, χ))
+        al = reshape(l, χ, d, χ)
+        real(local_energy(al, ac, h))
     end
-
-    E = real(local_energy(A.AL, A.AC, h))
-    if Hamiltonian
-        E, A, Hamiltonian_construction(h, A, E; tol = tol)...
-    else
-        E, A
+    if G !== nothing
+        G .= dx
     end
+    if F !== nothing
+        return val
+    end
+end
+
+function _mixed_canonical_from_ac(AC)
+    χ, d, = size(AC)
+    L, = polar(reshape(AC, χ * d, χ))
+    AL = reshape(L, χ, d, χ)
+    C, R = polar(reshape(AC, χ, d * χ); rev = true)
+    AR = reshape(R, χ, d, χ)
+    MixedCanonicalMPS(AL, AR, AC, C)
+end
+
+function _optimize_mps(h, A; tol, iterations, verbose)
+    χ, d, = size(A.AL)
+    AC = _initial_ac(A)
+    fg! = (F, G, x) -> _objective_gradient!(F, G, x, h, χ, d)
+    options = Optim.Options(g_abstol = tol, allow_f_increases = true, iterations = iterations, show_trace = _show_trace(verbose))
+    res = optimize(only_fg!(fg!), AC, LBFGS(manifold = UniformMPS(; verbose)), options)
+    AC .= Optim.minimizer(res)
+    _mixed_canonical_from_ac(AC)
+end
+
+function svumps(h::T, A; tol = 1e-8, iterations = 1000, verbose = false) where T
+    # Zygote.ignore is required for the Hellmann-Feynman gradient: gradients
+    # should flow through the final expectation value, not through the optimizer.
+    A0 = A
+    Aopt = ignore() do
+        _optimize_mps(h, A0; tol, iterations, verbose)
+    end
+    Aout = Aopt::typeof(A)
+
+    E = real(local_energy(Aout.AL, Aout.AC, h))
+    E, Aout
+end
+
+function svumps_hamiltonian(h::T, A; tol = 1e-8, iterations = 1000, verbose = false) where T
+    E, A = svumps(h, A; tol, iterations, verbose)
+    E, A, Hamiltonian_construction(h, A, E; tol = tol, verbose)...
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,0 +1,83 @@
+using LinearAlgebra
+using Test
+
+using SuperVUMPS
+using Zygote
+
+include("spin_models.jl")
+using .SpinModels
+
+function assert_mps_shape(A, χ, d)
+    @test size(A.AL) == (χ, d, χ)
+    @test size(A.AR) == (χ, d, χ)
+    @test size(A.AC) == (χ, d, χ)
+    @test size(A.C) == (χ, χ)
+end
+
+@testset "spin model fixtures" begin
+    for h in (transverse_field_ising(), heisenberg())
+        @test size(h) == (2, 2, 2, 2)
+        H = reshape(h, 4, 4)
+        @test H ≈ H'
+    end
+end
+
+@testset "canonical MPS" begin
+    χ = 2
+    d = 2
+    A = canonicalMPS(ComplexF64, χ, d)
+    assert_mps_shape(A, χ, d)
+    @test isapprox(norm(A.C), 1; atol = 1e-10)
+end
+
+@testset "local energy" begin
+    χ = 2
+    d = 2
+    A = canonicalMPS(ComplexF64, χ, d)
+
+    for h in (transverse_field_ising(; g = 0.7), heisenberg(; hz = 0.2))
+        E = local_energy(A.AL, A.AC, h)
+        @test isfinite(real(E))
+        @test isapprox(imag(E), 0; atol = 1e-8)
+    end
+end
+
+@testset "svumps smoke tests" begin
+    for h in (transverse_field_ising(; g = 1.0), heisenberg())
+        χ = 2
+        d = 2
+        A = canonicalMPS(ComplexF64, χ, d)
+        E, A2 = svumps(h, A; tol = 1e-5, iterations = 2, verbose = false)
+
+        @test isfinite(E)
+        assert_mps_shape(A2, χ, d)
+        @test isfinite(real(local_energy(A2.AL, A2.AC, h)))
+    end
+end
+
+@testset "Hellmann-Feynman gradient" begin
+    χ = 2
+    d = 2
+    h = transverse_field_ising(; g = 0.9)
+    A = canonicalMPS(ComplexF64, χ, d)
+    kwargs = (; tol = 1e-5, iterations = 1, verbose = false)
+
+    _, Aopt = svumps(h, A; kwargs...)
+    actual = Zygote.gradient(x -> svumps(x, A; kwargs...)[1], h)[1]
+    expected = Zygote.gradient(x -> real(local_energy(Aopt.AL, Aopt.AC, x)), h)[1]
+
+    @test actual ≈ expected atol = 1e-8 rtol = 1e-8
+end
+
+@testset "Hamiltonian construction" begin
+    χ = 2
+    d = 2
+    h = transverse_field_ising(; g = 1.0)
+    A = canonicalMPS(ComplexF64, χ, d)
+    E, A2, HAC, HC = svumps_hamiltonian(h, A; tol = 1e-5, iterations = 1, verbose = false)
+
+    @test isfinite(E)
+    assert_mps_shape(A2, χ, d)
+    @test size(HAC) == (χ, d, χ, χ, d, χ)
+    @test size(HC) == (χ, χ, χ, χ)
+end

--- a/test/spin_models.jl
+++ b/test/spin_models.jl
@@ -1,0 +1,28 @@
+module SpinModels
+
+using LinearAlgebra
+
+export transverse_field_ising, heisenberg
+
+const σx = ComplexF64[0 1; 1 0]
+const σy = ComplexF64[0 -im; im 0]
+const σz = ComplexF64[1 0; 0 -1]
+const I2 = Matrix{ComplexF64}(I, 2, 2)
+
+two_site_tensor(H) = reshape(Matrix{ComplexF64}(H), 2, 2, 2, 2)
+
+function transverse_field_ising(; J = 1.0, g = 1.0)
+    H = -J * kron(σz, σz) - (g / 2) * (kron(σx, I2) + kron(I2, σx))
+    two_site_tensor(H)
+end
+
+function heisenberg(; J = 1.0, hz = 0.0)
+    Sx = σx / 2
+    Sy = σy / 2
+    Sz = σz / 2
+    H = J * (kron(Sx, Sx) + kron(Sy, Sy) + kron(Sz, Sz))
+    H -= (hz / 2) * (kron(σz, I2) + kron(I2, σz))
+    two_site_tensor(H)
+end
+
+end


### PR DESCRIPTION
## Summary

- Bump the package version to 1.6.3.
- Add verbose plumbing for VUMPS-related Krylov/Optim paths.
- Add TFIM and Heisenberg benchmark scripts plus basic test coverage for spin fixtures, local energy, svumps smoke tests, Hellmann-Feynman gradients, and Hamiltonian construction.
- Split the Hamiltonian-returning API into `svumps_hamiltonian` so plain `svumps` has a stable `(E, A)` return shape.
- Refactor tangent projection, optimization setup, and Hamiltonian construction helpers while preserving the Hellmann-Feynman `Zygote.ignore` behavior.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'`
- Benchmark spot checks with TFIM and Heisenberg at small and heavier bond dimensions.
- Heisenberg convergence check: `chi=8` and `chi=16` stabilized by `iterations=300/1000`; `chi=32` reached `E = -0.442357495336` at `iterations=100` but longer runs hit `LineSearches` / `Optim` assertion `B > A`, which is a useful follow-up target for optimizer configurability.

## Notes

`Zygote.ignore` is intentionally retained because the Hellmann-Feynman gradient should flow through the final expectation value, not through the optimizer internals.