### PR TITLE
[codex] Add end-to-end VUMPS tests

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "SuperVUMPS"
 uuid = "251f20e1-0c2c-4c9f-ab3f-16280b56c0f4"
-version = "1.6.4"
+version = "1.6.5"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]
@@ -15,7 +15,8 @@ Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 [compat]
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Random", "Test"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,4 +1,5 @@
 using LinearAlgebra
+using Random
 using Test
 
 using SuperVUMPS
@@ -52,6 +53,38 @@ end
         @test isfinite(E)
         assert_mps_shape(A2, χ, d)
         @test isfinite(real(local_energy(A2.AL, A2.AC, h)))
+    end
+end
+
+@testset "svumps end-to-end chi=4" begin
+    χ = 4
+    d = 2
+    cases = (
+        ("transverse-field Ising", transverse_field_ising(; g = 1.0), -1.24),
+        ("Heisenberg", heisenberg(), -0.42),
+    )
+
+    for (name, h, energy_bound) in cases
+        @testset "$name" begin
+            Random.seed!(1234)
+            A0 = canonicalMPS(ComplexF64, χ, d)
+
+            E0 = real(local_energy(A0.AL, A0.AC, h))
+            E, A = svumps(h, A0; tol = 1e-6, iterations = 25)
+
+            @test isfinite(E)
+            @test E < E0
+            @test E < energy_bound
+            @test E ≈ real(local_energy(A.AL, A.AC, h)) atol = 1e-10
+
+            assert_mps_shape(A, χ, d)
+            @test isapprox(norm(A.C), 1; atol = 1e-8)
+
+            left_AC = reshape(reshape(A.AL, χ * d, χ) * A.C, χ, d, χ)
+            right_AC = reshape(A.C * reshape(A.AR, χ, d * χ), χ, d, χ)
+            @test A.AC ≈ left_AC atol = 1e-8
+            @test A.AC ≈ right_AC atol = 1e-8
+        end
     end
 end
 


### PR DESCRIPTION
## Summary

- Bump the package version to 1.6.5.
- Add deterministic chi=4 end-to-end VUMPS tests for transverse-field Ising and Heisenberg models.
- Assert energy improvement, finite results, local-energy consistency, MPS shape, C normalization, and mixed-canonical AC consistency.

## Validation

- `julia --project=. -e 'using Pkg; t = @elapsed Pkg.test(); println("TOTAL_ELAPSED_SECONDS=", t)'`
- Passed in 33.33 seconds locally.