### PR TITLE
[codex] Prepare v1.6.6 tests and ChainRulesCore ignore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,9 +1,10 @@
 name = "SuperVUMPS"
 uuid = "251f20e1-0c2c-4c9f-ab3f-16280b56c0f4"
-version = "1.6.5"
+version = "1.6.6"
 authors = ["MGYamada <myspinor@gmail.com>"]
 
 [deps]
+ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
 KrylovKit = "0b1a1467-8014-51b9-945f-bf0ae24f4b77"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 NLSolversBase = "d41bc354-129a-5804-8e4c-c37616107c6c"

--- a/src/SuperVUMPS.jl
+++ b/src/SuperVUMPS.jl
@@ -1,6 +1,7 @@
 module SuperVUMPS
 
 using LinearAlgebra
+using ChainRulesCore
 using OMEinsum
 using Zygote
 using NLSolversBase

--- a/src/vumps.jl
+++ b/src/vumps.jl
@@ -179,7 +179,7 @@ function Hamiltonian_construction(h::Array{T, 4}, A, E; tol = 1e-12) where T
 end
 
 function svumps(h::T, A; tol = 1e-8, iterations = 1000, Hamiltonian = false) where T
-    ignore() do
+    ChainRulesCore.ignore_derivatives() do
         χ, d, = size(A.AL)
         U, _, V = svd(A.C)
         AC = ein"ij, (jkl, lm) -> ikm"(U', A.AC, V)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -15,6 +15,14 @@ function assert_mps_shape(A, χ, d)
     @test size(A.C) == (χ, χ)
 end
 
+function random_hermitian_tensor(T, d, n)
+    dim = d^n
+    H = randn(T, dim, dim)
+    H = (H + H') ./ 2
+    reshape(H, ntuple(_ -> d, 2n))
+end
+
+@testset "SuperVUMPS" begin
 @testset "spin model fixtures" begin
     for h in (transverse_field_ising(), heisenberg())
         @test size(h) == (2, 2, 2, 2)
@@ -31,12 +39,40 @@ end
     @test isapprox(norm(A.C), 1; atol = 1e-10)
 end
 
+@testset "polar decomposition" begin
+    A = randn(ComplexF64, 4, 3)
+    Q, P = SuperVUMPS.polar(A)
+
+    @test Q' * Q ≈ Matrix{ComplexF64}(I, 3, 3) atol = 1e-10
+    @test P ≈ P' atol = 1e-10
+    @test Q * P ≈ A atol = 1e-10
+
+    B = randn(ComplexF64, 3, 4)
+    P_rev, Q_rev = SuperVUMPS.polar(B; rev = true)
+
+    @test Q_rev * Q_rev' ≈ Matrix{ComplexF64}(I, 3, 3) atol = 1e-10
+    @test P_rev ≈ P_rev' atol = 1e-10
+    @test P_rev * Q_rev ≈ B atol = 1e-10
+end
+
 @testset "local energy" begin
     χ = 2
     d = 2
     A = canonicalMPS(ComplexF64, χ, d)
 
     for h in (transverse_field_ising(; g = 0.7), heisenberg(; hz = 0.2))
+        E = local_energy(A.AL, A.AC, h)
+        @test isfinite(real(E))
+        @test isapprox(imag(E), 0; atol = 1e-8)
+    end
+end
+
+@testset "local energy higher-body tensors" begin
+    χ = 2
+    d = 2
+    A = canonicalMPS(ComplexF64, χ, d)
+
+    for h in (random_hermitian_tensor(ComplexF64, d, 3), random_hermitian_tensor(ComplexF64, d, 4))
         E = local_energy(A.AL, A.AC, h)
         @test isfinite(real(E))
         @test isapprox(imag(E), 0; atol = 1e-8)
@@ -113,4 +149,7 @@ end
     assert_mps_shape(A2, χ, d)
     @test size(HAC) == (χ, d, χ, χ, d, χ)
     @test size(HC) == (χ, χ, χ, χ)
+    @test reshape(HAC, χ * d * χ, χ * d * χ) ≈ reshape(HAC, χ * d * χ, χ * d * χ)' atol = 1e-8
+    @test reshape(HC, χ * χ, χ * χ) ≈ reshape(HC, χ * χ, χ * χ)' atol = 1e-8
+end
 end


### PR DESCRIPTION
## Summary

- Bump the package version to v1.6.6.
- Replace deprecated `ignore()` usage with `ChainRulesCore.ignore_derivatives()` and add `ChainRulesCore` as a direct dependency.
- Wrap tests in a single outer testset so the test output is summarized as one foldable block.
- Add regression coverage for higher-body `local_energy` tensors, `polar` decomposition behavior, and Hermitian structure from `Hamiltonian_construction`.

## Why

This prepares the package for follow-up refactoring by removing a deprecation path and broadening tests around numerical routines that are likely to be touched next.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'`
- `git diff --check`